### PR TITLE
Enclose regex pattern with ^ and $

### DIFF
--- a/controllers/syncconfig_controller.go
+++ b/controllers/syncconfig_controller.go
@@ -124,6 +124,7 @@ func (r *SyncConfigReconciler) Reconcile(req ctrl.Request) (result ctrl.Result, 
 		rc.SetStatusCondition(CreateStatusConditionReady(false))
 		return ctrl.Result{Requeue: false}, r.updateStatus(rc)
 	}
+	rc.SetStatusIfExisting(syncv1alpha1.SyncConfigInvalid, corev1.ConditionFalse)
 
 	namespaces, reconcileErr := r.getNamespaces(rc)
 	if reconcileErr != nil {

--- a/controllers/syncconfig_controller.go
+++ b/controllers/syncconfig_controller.go
@@ -118,7 +118,7 @@ func (r *SyncConfigReconciler) Reconcile(req ctrl.Request) (result ctrl.Result, 
 		conditions: make(map[syncv1alpha1.SyncConfigConditionType]syncv1alpha1.SyncConfigCondition),
 	}
 	r.Log.Info("Reconciling", getLoggingKeysAndValuesForSyncConfig(rc.cfg)...)
-	err = r.validateSpec(rc)
+	err = rc.validateSpec()
 	if err != nil {
 		rc.SetStatusCondition(CreateStatusConditionInvalid(err))
 		rc.SetStatusCondition(CreateStatusConditionReady(false))

--- a/controllers/syncconfig_status.go
+++ b/controllers/syncconfig_status.go
@@ -32,6 +32,14 @@ func (rc *ReconciliationContext) SetStatusCondition(condition SyncConfigConditio
 	rc.conditions[condition.Type] = condition
 }
 
+// SetStatusIfExisting sets the condition of the given type to the given status, if the condition already exists, otherwise noop
+func (rc *ReconciliationContext) SetStatusIfExisting(conditionType SyncConfigConditionType, status v1.ConditionStatus) {
+	if condition, found := rc.conditions[conditionType]; found {
+		condition.Status = status
+		rc.conditions[conditionType] = condition
+	}
+}
+
 // CreateStatusConditionReady is a shortcut for adding a SyncConfigReady condition.
 func CreateStatusConditionReady(isReady bool) SyncConfigCondition {
 	readyCondition := SyncConfigCondition{

--- a/controllers/syncconfig_utils.go
+++ b/controllers/syncconfig_utils.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 )
 
-func (r *SyncConfigReconciler) validateSpec(rc *ReconciliationContext) error {
+func (rc *ReconciliationContext) validateSpec() error {
 	spec := rc.cfg.Spec
 	if hasNoNamespaceSelector(rc.cfg.Spec) {
 		return fmt.Errorf("either .spec.namespaceSelector.matchNames or .spec.namespaceSelector.labelSelector is required")
@@ -18,14 +18,15 @@ func (r *SyncConfigReconciler) validateSpec(rc *ReconciliationContext) error {
 		return fmt.Errorf("either spec.deleteItems or .spec.syncItems is required")
 	}
 	for _, pattern := range spec.NamespaceSelector.MatchNames {
-		rgx, err := regexp.Compile(pattern)
+		// Adding ^ and $ even if they exist already should not be a problem, the string would still match with ^^pattern$$
+		rgx, err := regexp.Compile(fmt.Sprintf("^%s$", pattern))
 		if err != nil {
 			return fmt.Errorf(".spec.namespaceSelector.matchNames pattern invalid: %w", err)
 		}
 		rc.matchNamesRegex = append(rc.matchNamesRegex, rgx)
 	}
 	for _, pattern := range spec.NamespaceSelector.IgnoreNames {
-		rgx, err := regexp.Compile(pattern)
+		rgx, err := regexp.Compile(fmt.Sprintf("^%s$", pattern))
 		if err != nil {
 			return fmt.Errorf(".spec.namespaceSelector.ignoreNames pattern invalid: %w", err)
 		}


### PR DESCRIPTION
To ensure that pattern with just names would not match names that also would match the pattern.

Closes #39 