### PR TITLE
GH Action: Don't use shallow clones for releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,15 @@ on:
     - "*"
 
 env:
-  GO_VERSION: "^1.14.7"
+  GO_VERSION: "^1.15.2"
 
 jobs:
   dist:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GO_VERSION }}


### PR DESCRIPTION
Goreleaser otherwise can't generate the changelog since the local git history is missing.

See also https://github.com/goreleaser/goreleaser/issues/1896