### PR TITLE
Add quay.io as docker image mirror

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Login to Docker hub
-      run: docker login -u ${{ secrets.DOCKER_HUB_USER }} -p ${{ secrets.DOCKER_HUB_PASSWORD }}
+      run: docker login -u "${{ secrets.DOCKER_HUB_USER }}" -p "${{ secrets.DOCKER_HUB_PASSWORD }}"
+    - name: Login to quay.io
+      run: docker login -u "${{ secrets.QUAY_IO_USER }}" -p "${{ secrets.QUAY_IO_PASSWORD }}" quay.io
     - name: Generate artifacts
       run: make crd
     - name: Publish releases

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,6 +26,9 @@ dockers:
   - "docker.io/vshn/espejo:latest"
   - "docker.io/vshn/espejo:v{{ .Version }}"
   - "docker.io/vshn/espejo:v{{ .Major }}"
+  - "quay.io/vshn/espejo:latest"
+  - "quay.io/vshn/espejo:v{{ .Version }}"
+  - "quay.io/vshn/espejo:v{{ .Major }}"
 
 changelog:
   sort: asc


### PR DESCRIPTION
Already done:
* GH Secrets configured
* quay.io robot account created
* latest, v0.3.2 and v0 tags copied to quay.io/vshn/espejo