### PR TITLE
Determine Go version in Workflows from go.mod

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,21 +3,20 @@ name: Build
 on:
   push:
     branches:
-    - "master"
+    - master
     tags-ignore:
     - "*"
   pull_request:
     branches:
       - master
 
-env:
-  GO_VERSION: "^1.15.2"
-
 jobs:
   dist:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Determine Go version from go.mod
+      run: echo "GO_VERSION=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GO_VERSION }}
@@ -37,6 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Determine Go version from go.mod
+      run: echo "GO_VERSION=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GO_VERSION }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,21 +3,20 @@ name: Lint
 on:
   push:
     branches:
-    - "master"
+    - master
     tags-ignore:
     - "*"
   pull_request:
     branches:
     - master
 
-env:
-  GO_VERSION: "^1.15.2"
-
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Determine Go version from go.mod
+      run: echo "GO_VERSION=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GO_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,6 @@ on:
     tags:
     - "*"
 
-env:
-  GO_VERSION: "^1.15.2"
-
 jobs:
   dist:
     runs-on: ubuntu-latest
@@ -15,6 +12,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - name: Determine Go version from go.mod
+      run: echo "GO_VERSION=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GO_VERSION }}


### PR DESCRIPTION
Reduces maintenance, go.mod is source of truth since we are not using matrix builds