### PR TITLE
Use XEmbeddedResource Marker

### DIFF
--- a/api/v1alpha1/syncconfig_types.go
+++ b/api/v1alpha1/syncconfig_types.go
@@ -20,6 +20,7 @@ type (
 
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:EmbeddedResource
+	// +kubebuilder:validation:XEmbeddedResource
 
 	// SyncItem is an unstructured, "free-form" Kubernetes resource, complete with GVK, metadata and spec.
 	SyncItem unstructured.Unstructured

--- a/config/crd/apiextensions.k8s.io/v1/base/sync.appuio.ch_syncconfigs.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/base/sync.appuio.ch_syncconfigs.yaml
@@ -113,6 +113,7 @@ spec:
                 items:
                   description: SyncItem is an unstructured, "free-form" Kubernetes resource, complete with GVK, metadata and spec.
                   type: object
+                  x-kubernetes-embedded-resource: true
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
             type: object

--- a/config/crd/apiextensions.k8s.io/v1beta1/base/sync.appuio.ch_syncconfigs.yaml
+++ b/config/crd/apiextensions.k8s.io/v1beta1/base/sync.appuio.ch_syncconfigs.yaml
@@ -113,6 +113,7 @@ spec:
               items:
                 description: SyncItem is an unstructured, "free-form" Kubernetes resource, complete with GVK, metadata and spec.
                 type: object
+                x-kubernetes-embedded-resource: true
                 x-kubernetes-preserve-unknown-fields: true
               type: array
           type: object


### PR DESCRIPTION

## Summary
Apparently using the `// +kubebuilder:validation:XEmbeddedResource` marker is not recognized by the current CRD generator code.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [ ] Keep pull requests small so they can be easily reviewed.
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [ ] Update the documentation.
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
