### PR TITLE
Fix bug in reconcile loop that unconditionally updated every resource

### DIFF
--- a/controllers/syncconfig_controller_test.go
+++ b/controllers/syncconfig_controller_test.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/vshn/espejo/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
@@ -82,8 +84,8 @@ func (ts *SyncConfigControllerTestSuite) Test_GivenSyncConfig_WhenReconcile_Then
 		},
 	}
 	cm.Namespace = ts.NS
-  cm.Data["PROJECT_NAME"] = "wrong"
-  cm.Data["other"] = "new"
+	cm.Data["PROJECT_NAME"] = "wrong"
+	cm.Data["other"] = "new"
 	ts.EnsureResources(cm, sc)
 	result, err := ts.reconciler.Reconcile(context.TODO(), ctrl.Request{
 		NamespacedName: ts.MapToNamespacedName(sc),
@@ -93,7 +95,61 @@ func (ts *SyncConfigControllerTestSuite) Test_GivenSyncConfig_WhenReconcile_Then
 
 	ts.FetchResource(ts.MapToNamespacedName(cm), cm)
 	ts.Assert().Equal(ts.NS, cm.Data["PROJECT_NAME"])
-  ts.Assert().NotContains(cm.Data, "other")
+	ts.Assert().NotContains(cm.Data, "other")
+
+	ts.FetchResource(ts.MapToNamespacedName(sc), sc)
+	ts.Assert().Equal(int64(0), sc.Status.DeletedItemCount)
+	ts.Assert().Equal(int64(0), sc.Status.FailedItemCount)
+	ts.Assert().Equal(int64(1), sc.Status.SynchronizedItemCount)
+}
+
+type invalidUpdateClient struct {
+	client.Client
+}
+
+func (c invalidUpdateClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	return apierrors.NewInvalid(obj.GetObjectKind().GroupVersionKind().GroupKind(), obj.GetName(), nil)
+}
+func (c invalidUpdateClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+  // Envtest cannot handle foreground deletions used in force recreate as no GC controller is running, so we drop options
+  return c.Client.Delete(ctx, obj)
+}
+
+func (ts *SyncConfigControllerTestSuite) Test_GivenForceSyncConfig_WhenReconcile_ThenForceUpdateResources() {
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-configmap",
+		},
+		Data: map[string]string{"PROJECT_NAME": "${PROJECT_NAME}"},
+	}
+	sc := &SyncConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-syncconfig", Namespace: ts.NS},
+		Spec: SyncConfigSpec{
+			SyncItems:         []unstructured.Unstructured{toUnstructured(ts.T(), cm)},
+			NamespaceSelector: &NamespaceSelector{MatchNames: []string{ts.NS}},
+			ForceRecreate:     true,
+		},
+	}
+	cm.Namespace = ts.NS
+	cm.Data["PROJECT_NAME"] = "wrong"
+	cm.Data["other"] = "new"
+	ts.EnsureResources(cm, sc)
+	reconciler := &SyncConfigReconciler{
+		Client: invalidUpdateClient{ts.reconciler.Client},
+		Log:    ts.reconciler.Log,
+		Scheme: ts.reconciler.Scheme,
+	}
+
+	result, err := reconciler.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: ts.MapToNamespacedName(sc),
+	})
+	ts.Require().NoError(err)
+	ts.Assert().NotNil(result)
+
+	ts.FetchResource(ts.MapToNamespacedName(cm), cm)
+	ts.Assert().Equal(ts.NS, cm.Data["PROJECT_NAME"])
+	ts.Assert().NotContains(cm.Data, "other")
 
 	ts.FetchResource(ts.MapToNamespacedName(sc), sc)
 	ts.Assert().Equal(int64(0), sc.Status.DeletedItemCount)

--- a/controllers/syncconfig_controller_test.go
+++ b/controllers/syncconfig_controller_test.go
@@ -4,6 +4,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -111,8 +112,8 @@ func (c invalidUpdateClient) Update(ctx context.Context, obj client.Object, opts
 	return apierrors.NewInvalid(obj.GetObjectKind().GroupVersionKind().GroupKind(), obj.GetName(), nil)
 }
 func (c invalidUpdateClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
-  // Envtest cannot handle foreground deletions used in force recreate as no GC controller is running, so we drop options
-  return c.Client.Delete(ctx, obj)
+	// Envtest cannot handle foreground deletions used in force recreate as no GC controller is running, so we drop options
+	return c.Client.Delete(ctx, obj)
 }
 
 func (ts *SyncConfigControllerTestSuite) Test_GivenForceSyncConfig_WhenReconcile_ThenForceUpdateResources() {
@@ -204,4 +205,55 @@ func (ts *SyncConfigControllerTestSuite) Test_GivenInvalidConfig_WhenReconcile_T
 	ts.FetchResource(ts.MapToNamespacedName(sc), sc)
 	condition := meta.FindStatusCondition(sc.Status.Conditions, ConditionInvalid.String())
 	ts.Assert().NotNil(condition)
+}
+
+type readonlyClient struct {
+	client.Client
+}
+
+func (nu readonlyClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	return fmt.Errorf("No Update expected")
+}
+func (nu readonlyClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	return fmt.Errorf("No Create expected")
+}
+
+func (ts *SyncConfigControllerTestSuite) Test_GivenSyncConfigWithNoDiff_WhenReconcile_ThenNoOps() {
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-configmap",
+		},
+		Data: map[string]string{"PROJECT_NAME": "foo"},
+	}
+	sc := &SyncConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-syncconfig", Namespace: ts.NS},
+		Spec: SyncConfigSpec{
+			SyncItems:         []unstructured.Unstructured{toUnstructured(ts.T(), cm)},
+			NamespaceSelector: &NamespaceSelector{MatchNames: []string{ts.NS}},
+		},
+	}
+	cm.Namespace = ts.NS
+	ts.EnsureResources(cm, sc)
+	reconciler := &SyncConfigReconciler{
+		Client: readonlyClient{
+			ts.reconciler.Client,
+		},
+		Log:    ts.reconciler.Log,
+		Scheme: ts.reconciler.Scheme,
+	}
+	result, err := reconciler.Reconcile(ts.Ctx, ctrl.Request{
+		NamespacedName: ts.MapToNamespacedName(sc),
+	})
+	ts.Require().NoError(err)
+	ts.Assert().NotNil(result)
+
+	ts.FetchResource(ts.MapToNamespacedName(cm), cm)
+	ts.Assert().Equal("foo", cm.Data["PROJECT_NAME"])
+
+	ts.FetchResource(ts.MapToNamespacedName(sc), sc)
+	ts.Assert().Equal(int64(0), sc.Status.DeletedItemCount)
+	ts.Assert().Equal(int64(0), sc.Status.FailedItemCount)
+	ts.Assert().Equal(int64(1), sc.Status.SynchronizedItemCount)
+
 }

--- a/controllers/syncconfig_controller_test.go
+++ b/controllers/syncconfig_controller_test.go
@@ -66,6 +66,41 @@ func (ts *SyncConfigControllerTestSuite) Test_GivenNewSyncConfig_WhenReconcile_T
 	ts.Assert().Equal(int64(1), sc.Status.SynchronizedItemCount)
 }
 
+func (ts *SyncConfigControllerTestSuite) Test_GivenSyncConfig_WhenReconcile_ThenUpdateResources() {
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-configmap",
+		},
+		Data: map[string]string{"PROJECT_NAME": "${PROJECT_NAME}"},
+	}
+	sc := &SyncConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-syncconfig", Namespace: ts.NS},
+		Spec: SyncConfigSpec{
+			SyncItems:         []unstructured.Unstructured{toUnstructured(ts.T(), cm)},
+			NamespaceSelector: &NamespaceSelector{MatchNames: []string{ts.NS}},
+		},
+	}
+	cm.Namespace = ts.NS
+  cm.Data["PROJECT_NAME"] = "wrong"
+  cm.Data["other"] = "new"
+	ts.EnsureResources(cm, sc)
+	result, err := ts.reconciler.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: ts.MapToNamespacedName(sc),
+	})
+	ts.Require().NoError(err)
+	ts.Assert().NotNil(result)
+
+	ts.FetchResource(ts.MapToNamespacedName(cm), cm)
+	ts.Assert().Equal(ts.NS, cm.Data["PROJECT_NAME"])
+  ts.Assert().NotContains(cm.Data, "other")
+
+	ts.FetchResource(ts.MapToNamespacedName(sc), sc)
+	ts.Assert().Equal(int64(0), sc.Status.DeletedItemCount)
+	ts.Assert().Equal(int64(0), sc.Status.FailedItemCount)
+	ts.Assert().Equal(int64(1), sc.Status.SynchronizedItemCount)
+}
+
 func (ts *SyncConfigControllerTestSuite) Test_GivenSyncConfigWithDelete_WhenReconcile_ThenDeleteResource() {
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -88,3 +88,23 @@ func namespaceFromString(namespace string) v1.Namespace {
 		ObjectMeta: v12.ObjectMeta{Name: namespace},
 	}
 }
+
+// copyInto overwrites all non system managed fields of dst with the fields in src.
+// This can be used to update dst to the desired version src without creating a diff by removing system managed fields such as UID or SelfLink.
+func copyInto(dst, src *unstructured.Unstructured) {
+	tmp := dst.DeepCopy()
+	src.DeepCopyInto(dst)
+
+	dst.SetResourceVersion(tmp.GetResourceVersion())
+
+	dst.SetUID(tmp.GetUID())
+	dst.SetSelfLink(tmp.GetSelfLink())
+	dst.SetGeneration(tmp.GetGeneration())
+
+	dst.SetManagedFields(tmp.GetManagedFields())
+	dst.SetOwnerReferences(tmp.GetOwnerReferences())
+
+	dst.SetCreationTimestamp(tmp.GetCreationTimestamp())
+	dst.SetDeletionTimestamp(tmp.GetDeletionTimestamp())
+	dst.SetDeletionGracePeriodSeconds(tmp.GetDeletionGracePeriodSeconds())
+}


### PR DESCRIPTION
## Summary

Currently espejo updates every managed resource on every reconcile loop regardless of changes. We can verify that this is happening by observing the high `generation` number for espejo managed objects. On our internal test cluster the oldest espejo managed objects are at generation `35810`.

This result in a large amount of update calls and potentially overwhelms other controllers watching for changes of these objects.

This PR fixes this by only updating resource when there are actual changes to apply.

fixes #117 
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
