### PR TITLE
Ensure converted CDRs have new `preserveUnknownFields` default set

### DIFF
--- a/config/crd/apiextensions.k8s.io/v1/base/sync.appuio.ch_syncconfigs.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/base/sync.appuio.ch_syncconfigs.yaml
@@ -12,6 +12,7 @@ spec:
     listKind: SyncConfigList
     plural: syncconfigs
     singular: syncconfig
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/generate.go
+++ b/generate.go
@@ -3,4 +3,4 @@
 package main
 
 //go:generate go run sigs.k8s.io/controller-tools/cmd/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
-//go:generate go run sigs.k8s.io/controller-tools/cmd/controller-gen rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=${CRD_ROOT_DIR}/v1/base crd:crdVersions=v1
+//go:generate go run sigs.k8s.io/controller-tools/cmd/controller-gen rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=${CRD_ROOT_DIR}/v1/base crd:crdVersions=v1,deprecatedV1beta1CompatibilityPreserveUnknownFields=false


### PR DESCRIPTION
Newly applied `apiextensions.k8s.io/v1` set `preserveUnknownFields` to false. If the `apiextensions.k8s.io/v1` manifest was migrated from `apiextensions.k8s.io/v1beta1` `preserveUnknownFields` is set to true. This PR ensures all installations use the same default.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
